### PR TITLE
Final touches to get crx_mock working on 9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a [MoveIt Pro](https://picknik.ai/pro) robot configuration for FANUC robots.
 
 Refer to the [FANUC CRX Hardware Setup Guide](https://docs.picknik.ai/hardware_guides/fanuc_hardware_setup_guide/) for installation.
+
+> [!NOTE]
+> Make sure to match the `fanuc_driver` version to the controller software on your FANUC described [here](https://fanuc-corporation.github.io/fanuc_driver_doc/main/docs/fanuc_driver/fanuc_driver_overview.html).
+> This workspace is currently pulling in version `1.0.4`.

--- a/colcon-defaults.yaml
+++ b/colcon-defaults.yaml
@@ -15,6 +15,8 @@ build:
     - build-testing-on
     - coverage-gcc
     - coverage-pytest
+  packages-skip:
+    - fanuc_moveit_config
 test:
   event-handlers:
     - console_direct+

--- a/src/crx_mock/objectives/cycle.xml
+++ b/src/crx_mock/objectives/cycle.xml
@@ -17,6 +17,7 @@
           seed="0"
           velocity_scale_factor="1.0"
           waypoint_name="Up"
+          execution_pipeline="jtc"
         />
         <SubTree
           ID="Move to Waypoint"
@@ -31,6 +32,7 @@
           seed="0"
           velocity_scale_factor="1.0"
           waypoint_name="Home"
+          execution_pipeline="jtc"
         />
         <Action ID="AlwaysFailure" />
       </Control>

--- a/src/crx_mock/objectives/teleoperate.xml
+++ b/src/crx_mock/objectives/teleoperate.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Teleoperate">
+  <!--//////////-->
+  <BehaviorTree
+    ID="Teleoperate"
+    _description="Handles the different variations of teleoperation from the web UI. Can be used standalone."
+    _favorite="false"
+    _hardcoded="false"
+  >
+    <SubTree
+      ID="Request Teleoperation"
+      enable_user_interaction="false"
+      user_interaction_prompt=""
+      initial_teleop_mode="3"
+      controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+      joint_trajectory_controller_name="joint_trajectory_controller"
+      _collapsed="false"
+      execution_pipeline="jtc"
+    />
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Teleoperate">
+      <MetadataFields>
+        <Metadata subcategory="User Input" />
+        <Metadata runnable="true" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
- Updates fanuc driver to 1.0.4 to get cmake changes for ros2_control compatibility
- Modifies the default teleop objective [and cycle objective] to use the jtc pipeline

This PR was also tested on the office CRX.

Closes https://github.com/PickNikRobotics/moveit_pro/issues/17879